### PR TITLE
Remove Samples->Instruments envelope preservation (kills EMM386 #12 crash class); gate Shift-F4 to Instrument mode

### DIFF
--- a/IT_F.ASM
+++ b/IT_F.ASM
@@ -128,9 +128,7 @@ EndS
                 Extrn   Music_GetSongSegment:Far
                 Extrn   Music_InitMixTable:Far
                 Extrn   Music_InitMuteTable:Far
-                Extrn   Music_ClearInstrument:Far
                 Extrn   Music_ClearAllInstruments:Far
-                Extrn   Music_InstrumentHasEnvelopes:Far
                 Extrn   Music_SetGlobalVolume:Far
                 Extrn   Music_InitStereo:Far
                 Extrn   Music_Stop:Far
@@ -4840,37 +4838,7 @@ Proc            F_SetControlInstrument Far
                 Push    DS
 
                 Mov     DI, Offset O1_InitialiseInstrumentList
-                                                ; Default focus on the "No"
-                                                ; button so accidentally
-                                                ; pressing Enter on this
-                                                ; prompt does NOT wipe every
-                                                ; instrument header (and the
-                                                ; envelopes the user drew in
-                                                ; Sample mode).
-                                                ;
-                                                ; M_Object1List writes CX into
-                                                ; the list's header word; the
-                                                ; framework then locates the
-                                                ; focused object at
-                                                ; list+CX*2+6 (IT_M.ASM:463).
-                                                ; The +6 skips the idle-list
-                                                ; and key-list pointers, so
-                                                ; the focusable array is
-                                                ; 0-based from EmptyObject:
-                                                ;   3 = OK button
-                                                ;   4 = No button
-                                                ;   5 = list terminator (0)
-                                                ; A value of 6 ran two slots
-                                                ; PAST the terminator into the
-                                                ; next list's bytes -> garbage
-                                                ; object pointer -> wild Call
-                                                ; -> crash the instant the
-                                                ; dialog opened (and "nothing"
-                                                ; appeared selected). The "No"
-                                                ; button is index 4 -- exactly
-                                                ; where O1_ConfirmDelete puts
-                                                ; its default Cancel button.
-                Mov     CX, 4
+                Mov     CX, 3
                 Call    M_Object1List
                                                 ; DX = 0 -> don't initialise
                                                 ; DX = 1 -> initialise
@@ -4881,62 +4849,18 @@ Proc            F_SetControlInstrument Far
                 Test    DX, DX
                 JZ      F_SetControlInstrument3
 
-                                                ; Per-instrument envelope-
-                                                ; preserving init.
-                                                ;
-                                                ; The original code did an
-                                                ; unconditional
-                                                ; Music_ClearAllInstruments
-                                                ; then re-walked 0..99 to
-                                                ; copy sample names + fill
-                                                ; the 120-note keymap. That
-                                                ; wiped every Vol / Pan /
-                                                ; Pitch / Filter envelope
-                                                ; the user had drawn while
-                                                ; still in Sample mode
-                                                ; (envelopes don't sound in
-                                                ; Sample mode, so users
-                                                ; frequently pre-draw them
-                                                ; before flipping modes).
-                                                ;
-                                                ; Replacement: for each
-                                                ; slot 0..98, check whether
-                                                ; the live instrument's
-                                                ; envelope bytes deviate
-                                                ; from the default template
-                                                ; (Music_InstrumentHasEnvelopes
-                                                ;  in IT_MUSIC.ASM). If yes,
-                                                ; preserve the entire
-                                                ; instrument as-is. If no,
-                                                ; clear+re-init this single
-                                                ; slot exactly as before.
-                                                ; "Initialize Instruments =
-                                                ; YES" now means "set up
-                                                ; sample mappings on blank
-                                                ; instruments, leave my
-                                                ; envelopes alone."
+                Call    Music_ClearAllInstruments
 
+                                                ; OK.. for samples 1..99
+                                                ; check if sample exists.
+                                                ; if so, copy name&set all
+                                                ; notes of instrument.
                 Push    DS
                 Pop     ES                      ; ES = SongDataSegment
 
                 Xor     DX, DX
 
 F_SetControlInstrument1:
-                Mov     AX, DX
-                Call    Music_InstrumentHasEnvelopes
-                JNE     F_SetControlInstrument6 ; non-default envelope ->
-                                                ; preserve. Skip clear AND
-                                                ; skip the auto-name/keymap
-                                                ; fill below. Also skip the
-                                                ; network notify -- nothing
-                                                ; about this instrument
-                                                ; changed.
-
-                Mov     AX, DX                  ; envelope is default ->
-                Call    Music_ClearInstrument   ; safe to wipe this slot
-                                                ; back to template before
-                                                ; populating.
-
                 Mov     BX, DX
                 Add     BX, BX
                 Mov     SI, [DS:BX+64912]       ; SI points to sample
@@ -4975,8 +4899,6 @@ IF NETWORKENABLED
 F_SetControlInstrument5:
                 Call    Network_FinishedSendQueue
 ENDIF
-
-F_SetControlInstrument6:
                 Inc     DX
                 Cmp     DX, 99
                 JBE     F_SetControlInstrument1

--- a/IT_G.ASM
+++ b/IT_G.ASM
@@ -203,6 +203,7 @@ TempoSetMsg     DB      "Tempo set to ", 0FDh, "D beats per minute", 0
 SpeedSetMsg     DB      "Speed set to ", 0FDh, "D frames per row", 0
 VolumeSetMsg    DB      "Global Volume set to ", 0FDh, "D", 0
 MIDIMultiOffMsg DB      "MIDI multitimbral input OFF - normal MIDI restored", 0
+ShiftF4NeedInstrMsg DB  "Enable Instruments mode first (F12) to use Shift-F4", 0
 
 InstrumentScreenTable   Label
         DW      Offset O1_InstrumentListGeneral
@@ -320,6 +321,30 @@ EndP            Glbl_F3
 ;            router hijacking every note on channels 1..16.
 Proc            Glbl_Shift_F4 Far
 
+                                                ; Shift-F4 (multitimbral MIDI-in
+                                                ; batch-create / toggle) only
+                                                ; makes sense in Instrument
+                                                ; mode -- the 16 things it
+                                                ; creates ARE instruments.
+                                                ; Running it in Sample mode is
+                                                ; confusing, so gate it: bail
+                                                ; with an info-line hint when
+                                                ; bit 2 of the song flags
+                                                ; (Instrument mode) is clear.
+                Call    Music_GetSongSegment
+                Mov     DS, AX
+                        Assume DS:Nothing
+                Test    Byte Ptr [DS:2Ch], 4
+                JNZ     Glbl_Shift_F4_InstrMode
+
+                Push    CS
+                Pop     DS
+                Mov     SI, Offset ShiftF4NeedInstrMsg
+                Call    SetInfoLine
+                Mov     AX, 1
+                Ret
+
+Glbl_Shift_F4_InstrMode:
                 Call    Music_GetMIDIMultiEnable
                 Test    AL, AL
                 JZ      Glbl_Shift_F4_Create    ; currently off -> create+enable

--- a/IT_MUSIC.ASM
+++ b/IT_MUSIC.ASM
@@ -154,7 +154,6 @@ include network.inc
         Global  MIDIMultiEnable:Byte
         Global  Music_GetMIDIMultiEnable:Far
         Global  Music_SetMIDIMultiEnable:Far
-        Global  Music_InstrumentHasEnvelopes:Far
         Global  Music_GetHostChannelInformationTable:Far
         Global  Music_GetSlaveChannelInformationTable:Far
         Global  Music_SetGlobalVolume:Far
@@ -3959,87 +3958,12 @@ EndP            Music_ClearInstrument
                 Assume DS:Nothing
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-; Music_InstrumentHasEnvelopes -- AX = instrument number (0-based).
-;
-; Compares the envelope section of the live instrument header against the
-; default InstrumentHeader template. Bytes 130h..554 cover the Volume,
-; Pan, and Pitch/Filter envelope structs plus trailing padding (250 bytes
-; total). If any byte differs, the user has drawn (or otherwise edited)
-; envelope data on this instrument and it must NOT be wiped.
-;
-; Returns:
-;   ZF = 1 (Equal)   if envelope bytes match template (default-blank)
-;   ZF = 0 (NotEq)   if any envelope byte differs (custom data present)
-;
-; Used by F_SetControlInstrument to gate the per-instrument auto-init
-; during the F12 Samples -> Instruments mode flip, so envelopes drawn
-; while in Sample mode are preserved across the transition.
-;-------------------------------------------------------------------------------
-
-Proc            Music_InstrumentHasEnvelopes Far    ; AX = instrument number
-
-                Push    AX
-                Push    CX
-                Push    DS
-                Push    SI
-                Push    ES
-                Push    DI
-
-                Push    CS
-                Pop     DS
-                        Assume DS:Music
-
-                Mov     DI, AX
-                Add     DI, DI
-                Mov     ES, SongDataArea
-                Mov     DI, [ES:DI+64712]   ; ES:DI -> live instrument header
-
-                                            ; Fork: reject a structurally-
-                                            ; invalid instrument BEFORE the
-                                            ; template compare. A real IT
-                                            ; envelope has at most 25 nodes; a
-                                            ; node count > 25 in any of the
-                                            ; three envelopes (vol 130h, pan
-                                            ; 182h, pitch 1D4h -> counts at
-                                            ; +131h/+183h/+1D5h) means the slot
-                                            ; holds uninitialised / leftover
-                                            ; garbage, NOT user-drawn data.
-                                            ; Report "default" (ZF=1) so the
-                                            ; caller clears it to the template
-                                            ; rather than preserving garbage
-                                            ; that would later crash
-                                            ; I_MapEnvelope.
-                Cmp     Byte Ptr [ES:DI+131h], 25
-                JA      MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+183h], 25
-                JA      MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+1D5h], 25
-                JA      MIHE_Garbage
-
-                Add     DI, 130h            ; advance to envelope section
-                Mov     SI, Offset InstrumentHeader
-                Add     SI, 130h            ; matching offset in template
-                Mov     CX, 250             ; vol+pan+pitch envelopes + padding
-
-                ClD
-                RepE    CmpsB               ; ZF=1 if all 250 bytes match,
-                                            ; ZF=0 on first mismatch.
-                Jmp     MIHE_Done           ; (Jmp + Pops preserve flags.)
-
-MIHE_Garbage:
-                Cmp     SI, SI              ; force ZF=1 -> "default" -> clear
-
-MIHE_Done:
-                Pop     DI
-                Pop     ES
-                Pop     SI
-                Pop     DS
-                Pop     CX
-                Pop     AX
-                Ret
-
-EndP            Music_InstrumentHasEnvelopes
-                Assume DS:Nothing
+; Music_InstrumentHasEnvelopes was removed. It existed only to gate the F12
+; Samples -> Instruments "preserve drawn envelopes" feature, which is reverted
+; to upstream behaviour (F_SetControlInstrument now always clears+re-inits via
+; Music_ClearAllInstruments). The feature shipped a string of crashes (EMM386
+; #12 from garbage instrument headers reaching the envelope renderer, plus a
+; wild-call from a bad dialog-focus index) and was pulled at the source.
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 


### PR DESCRIPTION
Removes the cause of the recurring F12 Samples->Instruments crashes instead of patching symptoms. Restores F_SetControlInstrument to upstream IT2.15 behaviour (dialog opens on OK, confirm -> unconditional Music_ClearAllInstruments + clean re-init). Deletes the now-dead Music_InstrumentHasEnvelopes. Gates Glbl_Shift_F4 to Instrument mode. Keeps the I_MapEnvelope MaxNode<=25 clamp and the multitimbral feature. Builds clean: IT.EXE + 42 drivers. DO NOT MERGE yet -- opened for an audit pass. See branch commit message for full detail.