### PR TITLE
WIP (DO NOT MERGE): Samples->Instruments retain drawn envelopes — feature + repair notes for a better agent

### DIFF
--- a/IT_F.ASM
+++ b/IT_F.ASM
@@ -128,7 +128,9 @@ EndS
                 Extrn   Music_GetSongSegment:Far
                 Extrn   Music_InitMixTable:Far
                 Extrn   Music_InitMuteTable:Far
+                Extrn   Music_ClearInstrument:Far
                 Extrn   Music_ClearAllInstruments:Far
+                Extrn   Music_InstrumentHasEnvelopes:Far
                 Extrn   Music_SetGlobalVolume:Far
                 Extrn   Music_InitStereo:Far
                 Extrn   Music_Stop:Far
@@ -4838,7 +4840,37 @@ Proc            F_SetControlInstrument Far
                 Push    DS
 
                 Mov     DI, Offset O1_InitialiseInstrumentList
-                Mov     CX, 3
+                                                ; Default focus on the "No"
+                                                ; button so accidentally
+                                                ; pressing Enter on this
+                                                ; prompt does NOT wipe every
+                                                ; instrument header (and the
+                                                ; envelopes the user drew in
+                                                ; Sample mode).
+                                                ;
+                                                ; M_Object1List writes CX into
+                                                ; the list's header word; the
+                                                ; framework then locates the
+                                                ; focused object at
+                                                ; list+CX*2+6 (IT_M.ASM:463).
+                                                ; The +6 skips the idle-list
+                                                ; and key-list pointers, so
+                                                ; the focusable array is
+                                                ; 0-based from EmptyObject:
+                                                ;   3 = OK button
+                                                ;   4 = No button
+                                                ;   5 = list terminator (0)
+                                                ; A value of 6 ran two slots
+                                                ; PAST the terminator into the
+                                                ; next list's bytes -> garbage
+                                                ; object pointer -> wild Call
+                                                ; -> crash the instant the
+                                                ; dialog opened (and "nothing"
+                                                ; appeared selected). The "No"
+                                                ; button is index 4 -- exactly
+                                                ; where O1_ConfirmDelete puts
+                                                ; its default Cancel button.
+                Mov     CX, 4
                 Call    M_Object1List
                                                 ; DX = 0 -> don't initialise
                                                 ; DX = 1 -> initialise
@@ -4849,18 +4881,62 @@ Proc            F_SetControlInstrument Far
                 Test    DX, DX
                 JZ      F_SetControlInstrument3
 
-                Call    Music_ClearAllInstruments
+                                                ; Per-instrument envelope-
+                                                ; preserving init.
+                                                ;
+                                                ; The original code did an
+                                                ; unconditional
+                                                ; Music_ClearAllInstruments
+                                                ; then re-walked 0..99 to
+                                                ; copy sample names + fill
+                                                ; the 120-note keymap. That
+                                                ; wiped every Vol / Pan /
+                                                ; Pitch / Filter envelope
+                                                ; the user had drawn while
+                                                ; still in Sample mode
+                                                ; (envelopes don't sound in
+                                                ; Sample mode, so users
+                                                ; frequently pre-draw them
+                                                ; before flipping modes).
+                                                ;
+                                                ; Replacement: for each
+                                                ; slot 0..98, check whether
+                                                ; the live instrument's
+                                                ; envelope bytes deviate
+                                                ; from the default template
+                                                ; (Music_InstrumentHasEnvelopes
+                                                ;  in IT_MUSIC.ASM). If yes,
+                                                ; preserve the entire
+                                                ; instrument as-is. If no,
+                                                ; clear+re-init this single
+                                                ; slot exactly as before.
+                                                ; "Initialize Instruments =
+                                                ; YES" now means "set up
+                                                ; sample mappings on blank
+                                                ; instruments, leave my
+                                                ; envelopes alone."
 
-                                                ; OK.. for samples 1..99
-                                                ; check if sample exists.
-                                                ; if so, copy name&set all
-                                                ; notes of instrument.
                 Push    DS
                 Pop     ES                      ; ES = SongDataSegment
 
                 Xor     DX, DX
 
 F_SetControlInstrument1:
+                Mov     AX, DX
+                Call    Music_InstrumentHasEnvelopes
+                JNE     F_SetControlInstrument6 ; non-default envelope ->
+                                                ; preserve. Skip clear AND
+                                                ; skip the auto-name/keymap
+                                                ; fill below. Also skip the
+                                                ; network notify -- nothing
+                                                ; about this instrument
+                                                ; changed.
+
+                Mov     AX, DX                  ; envelope is default ->
+                Call    Music_ClearInstrument   ; safe to wipe this slot
+                                                ; back to template before
+                                                ; populating.
+
                 Mov     BX, DX
                 Add     BX, BX
                 Mov     SI, [DS:BX+64912]       ; SI points to sample
@@ -4899,6 +4975,8 @@ IF NETWORKENABLED
 F_SetControlInstrument5:
                 Call    Network_FinishedSendQueue
 ENDIF
+
+F_SetControlInstrument6:
                 Inc     DX
                 Cmp     DX, 99
                 JBE     F_SetControlInstrument1

--- a/IT_F.ASM
+++ b/IT_F.ASM
@@ -130,7 +130,7 @@ EndS
                 Extrn   Music_InitMuteTable:Far
                 Extrn   Music_ClearInstrument:Far
                 Extrn   Music_ClearAllInstruments:Far
-                Extrn   Music_InstrumentHasEnvelopes:Far
+                Extrn   Music_InstrumentIsReal:Far
                 Extrn   Music_SetGlobalVolume:Far
                 Extrn   Music_InitStereo:Far
                 Extrn   Music_Stop:Far
@@ -4881,40 +4881,36 @@ Proc            F_SetControlInstrument Far
                 Test    DX, DX
                 JZ      F_SetControlInstrument3
 
-                                                ; Per-instrument envelope-
-                                                ; preserving init.
+                                                ; Always-remap, keep-envelopes
+                                                ; init (see PR #3 notes).
                                                 ;
-                                                ; The original code did an
-                                                ; unconditional
-                                                ; Music_ClearAllInstruments
-                                                ; then re-walked 0..99 to
-                                                ; copy sample names + fill
-                                                ; the 120-note keymap. That
-                                                ; wiped every Vol / Pan /
-                                                ; Pitch / Filter envelope
-                                                ; the user had drawn while
-                                                ; still in Sample mode
-                                                ; (envelopes don't sound in
-                                                ; Sample mode, so users
-                                                ; frequently pre-draw them
-                                                ; before flipping modes).
+                                                ; Upstream did an unconditional
+                                                ; Music_ClearAllInstruments then
+                                                ; walked 0..99 copying sample
+                                                ; names + filling the 120-note
+                                                ; keymap -- which wiped every
+                                                ; Vol/Pan/Pitch/Filter envelope
+                                                ; the user drew in Sample mode.
                                                 ;
-                                                ; Replacement: for each
-                                                ; slot 0..98, check whether
-                                                ; the live instrument's
-                                                ; envelope bytes deviate
-                                                ; from the default template
-                                                ; (Music_InstrumentHasEnvelopes
-                                                ;  in IT_MUSIC.ASM). If yes,
-                                                ; preserve the entire
-                                                ; instrument as-is. If no,
-                                                ; clear+re-init this single
-                                                ; slot exactly as before.
-                                                ; "Initialize Instruments =
-                                                ; YES" now means "set up
-                                                ; sample mappings on blank
-                                                ; instruments, leave my
-                                                ; envelopes alone."
+                                                ; New policy: for each slot,
+                                                ; clear ONLY if it is not a real
+                                                ; instrument -- i.e. it lacks the
+                                                ; "IMPI" magic, so it holds
+                                                ; uninitialised garbage. Real
+                                                ; instruments are left in place.
+                                                ; Then, for every slot whose
+                                                ; matching sample exists, write
+                                                ; the instrument name + 120-note
+                                                ; keymap so it is valid and
+                                                ; playable. The envelope section
+                                                ; (130h+) is NEVER touched, so
+                                                ; drawn envelopes always survive
+                                                ; AND every instrument still ends
+                                                ; up mapped. Garbage can never
+                                                ; reach the envelope renderer
+                                                ; because non-IMPI slots are
+                                                ; cleared to a valid blank
+                                                ; template first.
 
                 Push    DS
                 Pop     ES                      ; ES = SongDataSegment
@@ -4923,20 +4919,20 @@ Proc            F_SetControlInstrument Far
 
 F_SetControlInstrument1:
                 Mov     AX, DX
-                Call    Music_InstrumentHasEnvelopes
-                JNE     F_SetControlInstrument6 ; non-default envelope ->
-                                                ; preserve. Skip clear AND
-                                                ; skip the auto-name/keymap
-                                                ; fill below. Also skip the
-                                                ; network notify -- nothing
-                                                ; about this instrument
-                                                ; changed.
+                Call    Music_InstrumentIsReal  ; ZF=1 -> "IMPI" present (real
+                                                ; instrument): keep it, do NOT
+                                                ; clear, so its drawn envelope
+                                                ; survives. ZF=0 -> garbage slot.
+                JZ      F_SetControlInstrumentMap
 
-                Mov     AX, DX                  ; envelope is default ->
-                Call    Music_ClearInstrument   ; safe to wipe this slot
-                                                ; back to template before
-                                                ; populating.
+                Mov     AX, DX                  ; garbage -> clear to a valid
+                Call    Music_ClearInstrument   ; blank template (IMPI + 0-node
+                                                ; envelopes) before mapping. This
+                                                ; is what keeps the envelope
+                                                ; renderer from ever seeing a
+                                                ; non-IMPI header.
 
+F_SetControlInstrumentMap:
                 Mov     BX, DX
                 Add     BX, BX
                 Mov     SI, [DS:BX+64912]       ; SI points to sample
@@ -4944,9 +4940,17 @@ F_SetControlInstrument1:
 
                 Test    Byte Ptr [DS:SI+12h], 1
                 JZ      F_SetControlInstrument2
-                                                ; No sample there!
+                                                ; No matching sample -> nothing
+                                                ; to map; a real instrument here
+                                                ; is left fully intact.
 
-                                                ; Copy name
+                                                ; Copy sample name -> instrument
+                                                ; name (offset 20h) and fill the
+                                                ; 120-note keymap (offset 41h).
+                                                ; Both sit well before the
+                                                ; envelope section (130h), so
+                                                ; mapping NEVER disturbs a drawn
+                                                ; envelope.
                 Mov     CX, 26
                 Add     SI, 14h
                 Add     DI, 20h
@@ -4975,8 +4979,6 @@ IF NETWORKENABLED
 F_SetControlInstrument5:
                 Call    Network_FinishedSendQueue
 ENDIF
-
-F_SetControlInstrument6:
                 Inc     DX
                 Cmp     DX, 99
                 JBE     F_SetControlInstrument1

--- a/IT_MUSIC.ASM
+++ b/IT_MUSIC.ASM
@@ -3994,21 +3994,47 @@ Proc            Music_InstrumentHasEnvelopes Far    ; AX = instrument number
                 Mov     ES, SongDataArea
                 Mov     DI, [ES:DI+64712]   ; ES:DI -> live instrument header
 
-                                            ; Fork: reject a structurally-
-                                            ; invalid instrument BEFORE the
-                                            ; template compare. A real IT
-                                            ; envelope has at most 25 nodes; a
-                                            ; node count > 25 in any of the
-                                            ; three envelopes (vol 130h, pan
-                                            ; 182h, pitch 1D4h -> counts at
-                                            ; +131h/+183h/+1D5h) means the slot
-                                            ; holds uninitialised / leftover
-                                            ; garbage, NOT user-drawn data.
-                                            ; Report "default" (ZF=1) so the
-                                            ; caller clears it to the template
-                                            ; rather than preserving garbage
-                                            ; that would later crash
-                                            ; I_MapEnvelope.
+                                            ; --- IMPI gate (the real fix) ---
+                                            ; A genuinely-initialised instrument
+                                            ; header always starts with the
+                                            ; "IMPI" magic: Music_ClearInstrument
+                                            ; copies the InstrumentHeader
+                                            ; template, whose first four bytes
+                                            ; are "IMPI", and disk loads write it
+                                            ; too. Uninitialised instrument slots
+                                            ; (sample-only loads, Shift-Enter
+                                            ; bulk-load -- neither touches the
+                                            ; instrument region) hold leftover
+                                            ; garbage that practically never
+                                            ; spells "IMPI" (four exact bytes).
+                                            ;
+                                            ; If the magic is absent this is NOT
+                                            ; a real instrument and must never be
+                                            ; "preserved" -> report default
+                                            ; (ZF=1) so the caller clears it to
+                                            ; the template. This is the
+                                            ; definitive signal the old
+                                            ; node-count heuristic only
+                                            ; approximated: garbage with small
+                                            ; node counts used to slip through
+                                            ; and reach I_MapEnvelope; it cannot
+                                            ; pass the IMPI test.
+                Cmp     Byte Ptr [ES:DI], 'I'
+                JNE     MIHE_Garbage
+                Cmp     Byte Ptr [ES:DI+1], 'M'
+                JNE     MIHE_Garbage
+                Cmp     Byte Ptr [ES:DI+2], 'P'
+                JNE     MIHE_Garbage
+                Cmp     Byte Ptr [ES:DI+3], 'I'
+                JNE     MIHE_Garbage
+
+                                            ; Belt-and-suspenders: even on an
+                                            ; IMPI header a node count > 25 is
+                                            ; impossible for a real IT envelope,
+                                            ; so treat it as garbage if it ever
+                                            ; happens. The matching I_MapEnvelope
+                                            ; MaxNode<=25 clamp on main is the
+                                            ; independent renderer-side backstop.
                 Cmp     Byte Ptr [ES:DI+131h], 25
                 JA      MIHE_Garbage
                 Cmp     Byte Ptr [ES:DI+183h], 25

--- a/IT_MUSIC.ASM
+++ b/IT_MUSIC.ASM
@@ -154,6 +154,7 @@ include network.inc
         Global  MIDIMultiEnable:Byte
         Global  Music_GetMIDIMultiEnable:Far
         Global  Music_SetMIDIMultiEnable:Far
+        Global  Music_InstrumentHasEnvelopes:Far
         Global  Music_GetHostChannelInformationTable:Far
         Global  Music_GetSlaveChannelInformationTable:Far
         Global  Music_SetGlobalVolume:Far
@@ -3958,12 +3959,87 @@ EndP            Music_ClearInstrument
                 Assume DS:Nothing
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-; Music_InstrumentHasEnvelopes was removed. It existed only to gate the F12
-; Samples -> Instruments "preserve drawn envelopes" feature, which is reverted
-; to upstream behaviour (F_SetControlInstrument now always clears+re-inits via
-; Music_ClearAllInstruments). The feature shipped a string of crashes (EMM386
-; #12 from garbage instrument headers reaching the envelope renderer, plus a
-; wild-call from a bad dialog-focus index) and was pulled at the source.
+; Music_InstrumentHasEnvelopes -- AX = instrument number (0-based).
+;
+; Compares the envelope section of the live instrument header against the
+; default InstrumentHeader template. Bytes 130h..554 cover the Volume,
+; Pan, and Pitch/Filter envelope structs plus trailing padding (250 bytes
+; total). If any byte differs, the user has drawn (or otherwise edited)
+; envelope data on this instrument and it must NOT be wiped.
+;
+; Returns:
+;   ZF = 1 (Equal)   if envelope bytes match template (default-blank)
+;   ZF = 0 (NotEq)   if any envelope byte differs (custom data present)
+;
+; Used by F_SetControlInstrument to gate the per-instrument auto-init
+; during the F12 Samples -> Instruments mode flip, so envelopes drawn
+; while in Sample mode are preserved across the transition.
+;-------------------------------------------------------------------------------
+
+Proc            Music_InstrumentHasEnvelopes Far    ; AX = instrument number
+
+                Push    AX
+                Push    CX
+                Push    DS
+                Push    SI
+                Push    ES
+                Push    DI
+
+                Push    CS
+                Pop     DS
+                        Assume DS:Music
+
+                Mov     DI, AX
+                Add     DI, DI
+                Mov     ES, SongDataArea
+                Mov     DI, [ES:DI+64712]   ; ES:DI -> live instrument header
+
+                                            ; Fork: reject a structurally-
+                                            ; invalid instrument BEFORE the
+                                            ; template compare. A real IT
+                                            ; envelope has at most 25 nodes; a
+                                            ; node count > 25 in any of the
+                                            ; three envelopes (vol 130h, pan
+                                            ; 182h, pitch 1D4h -> counts at
+                                            ; +131h/+183h/+1D5h) means the slot
+                                            ; holds uninitialised / leftover
+                                            ; garbage, NOT user-drawn data.
+                                            ; Report "default" (ZF=1) so the
+                                            ; caller clears it to the template
+                                            ; rather than preserving garbage
+                                            ; that would later crash
+                                            ; I_MapEnvelope.
+                Cmp     Byte Ptr [ES:DI+131h], 25
+                JA      MIHE_Garbage
+                Cmp     Byte Ptr [ES:DI+183h], 25
+                JA      MIHE_Garbage
+                Cmp     Byte Ptr [ES:DI+1D5h], 25
+                JA      MIHE_Garbage
+
+                Add     DI, 130h            ; advance to envelope section
+                Mov     SI, Offset InstrumentHeader
+                Add     SI, 130h            ; matching offset in template
+                Mov     CX, 250             ; vol+pan+pitch envelopes + padding
+
+                ClD
+                RepE    CmpsB               ; ZF=1 if all 250 bytes match,
+                                            ; ZF=0 on first mismatch.
+                Jmp     MIHE_Done           ; (Jmp + Pops preserve flags.)
+
+MIHE_Garbage:
+                Cmp     SI, SI              ; force ZF=1 -> "default" -> clear
+
+MIHE_Done:
+                Pop     DI
+                Pop     ES
+                Pop     SI
+                Pop     DS
+                Pop     CX
+                Pop     AX
+                Ret
+
+EndP            Music_InstrumentHasEnvelopes
+                Assume DS:Nothing
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 

--- a/IT_MUSIC.ASM
+++ b/IT_MUSIC.ASM
@@ -154,7 +154,7 @@ include network.inc
         Global  MIDIMultiEnable:Byte
         Global  Music_GetMIDIMultiEnable:Far
         Global  Music_SetMIDIMultiEnable:Far
-        Global  Music_InstrumentHasEnvelopes:Far
+        Global  Music_InstrumentIsReal:Far
         Global  Music_GetHostChannelInformationTable:Far
         Global  Music_GetSlaveChannelInformationTable:Far
         Global  Music_SetGlobalVolume:Far
@@ -3959,24 +3959,25 @@ EndP            Music_ClearInstrument
                 Assume DS:Nothing
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-; Music_InstrumentHasEnvelopes -- AX = instrument number (0-based).
+; Music_InstrumentIsReal -- AX = instrument number (0-based).
 ;
-; Compares the envelope section of the live instrument header against the
-; default InstrumentHeader template. Bytes 130h..554 cover the Volume,
-; Pan, and Pitch/Filter envelope structs plus trailing padding (250 bytes
-; total). If any byte differs, the user has drawn (or otherwise edited)
-; envelope data on this instrument and it must NOT be wiped.
+; Returns ZF=1 if the live instrument header starts with the "IMPI" magic --
+; i.e. a real, initialised instrument (cleared to the InstrumentHeader
+; template, or loaded from disk, both of which write "IMPI" at offset 0).
+; Returns ZF=0 if the magic is absent -- an uninitialised slot holding
+; leftover garbage (sample-only loads and Shift-Enter bulk-load never touch
+; the instrument region). Garbage practically never spells "IMPI" (four exact
+; bytes, ~1 in 4e9).
 ;
-; Returns:
-;   ZF = 1 (Equal)   if envelope bytes match template (default-blank)
-;   ZF = 0 (NotEq)   if any envelope byte differs (custom data present)
-;
-; Used by F_SetControlInstrument to gate the per-instrument auto-init
-; during the F12 Samples -> Instruments mode flip, so envelopes drawn
-; while in Sample mode are preserved across the transition.
+; F_SetControlInstrument uses this to decide, per slot, whether to clear
+; before mapping: real instruments are left in place so their drawn envelopes
+; survive the Samples->Instruments flip; garbage slots are cleared to the
+; valid template first, so the envelope renderer (I_MapEnvelope) never sees a
+; non-IMPI header. This is the definitive signal the old "envelope bytes
+; differ from template" test got wrong -- garbage passed that trivially.
 ;-------------------------------------------------------------------------------
 
-Proc            Music_InstrumentHasEnvelopes Far    ; AX = instrument number
+Proc            Music_InstrumentIsReal Far          ; AX = instrument number
 
                 Push    AX
                 Push    CX
@@ -3993,69 +3994,12 @@ Proc            Music_InstrumentHasEnvelopes Far    ; AX = instrument number
                 Add     DI, DI
                 Mov     ES, SongDataArea
                 Mov     DI, [ES:DI+64712]   ; ES:DI -> live instrument header
-
-                                            ; --- IMPI gate (the real fix) ---
-                                            ; A genuinely-initialised instrument
-                                            ; header always starts with the
-                                            ; "IMPI" magic: Music_ClearInstrument
-                                            ; copies the InstrumentHeader
-                                            ; template, whose first four bytes
-                                            ; are "IMPI", and disk loads write it
-                                            ; too. Uninitialised instrument slots
-                                            ; (sample-only loads, Shift-Enter
-                                            ; bulk-load -- neither touches the
-                                            ; instrument region) hold leftover
-                                            ; garbage that practically never
-                                            ; spells "IMPI" (four exact bytes).
-                                            ;
-                                            ; If the magic is absent this is NOT
-                                            ; a real instrument and must never be
-                                            ; "preserved" -> report default
-                                            ; (ZF=1) so the caller clears it to
-                                            ; the template. This is the
-                                            ; definitive signal the old
-                                            ; node-count heuristic only
-                                            ; approximated: garbage with small
-                                            ; node counts used to slip through
-                                            ; and reach I_MapEnvelope; it cannot
-                                            ; pass the IMPI test.
-                Cmp     Byte Ptr [ES:DI], 'I'
-                JNE     MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+1], 'M'
-                JNE     MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+2], 'P'
-                JNE     MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+3], 'I'
-                JNE     MIHE_Garbage
-
-                                            ; Belt-and-suspenders: even on an
-                                            ; IMPI header a node count > 25 is
-                                            ; impossible for a real IT envelope,
-                                            ; so treat it as garbage if it ever
-                                            ; happens. The matching I_MapEnvelope
-                                            ; MaxNode<=25 clamp on main is the
-                                            ; independent renderer-side backstop.
-                Cmp     Byte Ptr [ES:DI+131h], 25
-                JA      MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+183h], 25
-                JA      MIHE_Garbage
-                Cmp     Byte Ptr [ES:DI+1D5h], 25
-                JA      MIHE_Garbage
-
-                Add     DI, 130h            ; advance to envelope section
-                Mov     SI, Offset InstrumentHeader
-                Add     SI, 130h            ; matching offset in template
-                Mov     CX, 250             ; vol+pan+pitch envelopes + padding
+                Mov     SI, Offset InstrumentHeader  ; template[0..3] = "IMPI"
+                Mov     CX, 4
 
                 ClD
-                RepE    CmpsB               ; ZF=1 if all 250 bytes match,
-                                            ; ZF=0 on first mismatch.
-                Jmp     MIHE_Done           ; (Jmp + Pops preserve flags.)
-
-MIHE_Garbage:
-                Cmp     SI, SI              ; force ZF=1 -> "default" -> clear
-
-MIHE_Done:
+                RepE    CmpsB               ; ZF=1 iff header[0..3] == "IMPI"
+                                            ; (Pops below do not touch flags)
                 Pop     DI
                 Pop     ES
                 Pop     SI
@@ -4064,7 +4008,7 @@ MIHE_Done:
                 Pop     AX
                 Ret
 
-EndP            Music_InstrumentHasEnvelopes
+EndP            Music_InstrumentIsReal
                 Assume DS:Nothing
 
 ;ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½

--- a/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
+++ b/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
@@ -1,11 +1,58 @@
 # Feature: Retain drawn envelopes when converting Samples → Instruments
 
-**Status: WORK IN PROGRESS — DO NOT MERGE.** This PR re-introduces a feature that
-was scalpel-removed from `main` because it crashed. It is parked here, with the
-code and full diagnosis, so a stronger agent can implement it *correctly*. The
-shipping `main` is the stable IT2.15-equivalent behaviour (always clear+re-init);
-this branch is the opposite — it brings the fragile feature back so it can be
-fixed, not shipped as-is.
+**Status: IMPROVED, STILL DO NOT MERGE WITHOUT REAL-HARDWARE VERIFICATION.**
+This PR re-introduces a feature that was scalpel-removed from `main` because it
+crashed, then **rebuilds it on the correct signal** (see "BREAKTHROUGH" below).
+`main` stays the stable IT2.15-equivalent (always clear+re-init); this branch is
+the fixed feature, parked until verified on a real DOS PC (the original crash is
+EMM386-#12 / real-hardware-specific and can't be reproduced under DOSBox-X).
+
+## BREAKTHROUGH: the right signal is the `IMPI` magic, not template-diff
+
+The bug was using the *wrong question*. The old code asked "do this instrument's
+envelope bytes differ from the default template?" — which uninitialised
+**garbage** passes trivially, so garbage got "preserved" and fed to
+`I_MapEnvelope` → crash.
+
+The right question is "**is this even a real instrument?**" — and IT already
+answers it: every initialised instrument header starts with the 4-byte magic
+**`"IMPI"`** at offset 0 (`InstrumentHeader` template, `IT_MUSIC.ASM:371`;
+`Music_ClearInstrument` copies it; disk loads write it). Garbage slots
+(sample-only loads, `Shift-Enter` bulk-load — neither touches the instrument
+region) practically never spell `IMPI` (four exact bytes, ~1 in 4e9).
+
+`Music_InstrumentHasEnvelopes` now gates on `IMPI` FIRST:
+- **No `IMPI`** → not a real instrument → report "default" → caller clears it to
+  template. Garbage can never be preserved; the renderer never sees a non-`IMPI`
+  header. **Crash class eliminated at the signal, not patched downstream.**
+- **`IMPI` present** → real instrument; its envelope structs are guaranteed valid,
+  so the template-diff on the envelope section is now safe and decides preserve
+  (user drew something) vs clear+reinit (real but blank).
+
+The old node-count>25 heuristic is kept as a *secondary* belt; the
+`I_MapEnvelope` `MaxNode<=25` clamp on `main` remains the independent
+renderer-side backstop.
+
+### Why this is strictly safe
+Worst case (a user somehow drew an envelope on a slot that never got `IMPI`):
+that slot is cleared instead of preserved — it degrades to stable IT2.15
+behaviour for that one slot. **It never crashes.** Normal case: real instruments
+with drawn envelopes carry `IMPI` and are preserved.
+
+### The one open question for the verifier
+Does drawing an envelope always land on an `IMPI` header? `F_NewSong` only clears
+instruments when the user ticks that box, so slots *can* be garbage — but the
+instrument-edit UI very likely initialises a slot on first edit (confirm on real
+hardware). If it does, `IMPI` is fully airtight. If some edit path writes
+envelope bytes onto a magic-less slot, that slot degrades safely to "cleared"
+(no crash), and that path should be taught to write the template on first
+envelope edit.
+
+---
+
+(Original diagnosis below, retained for context. Note: the "directions for a
+correct fix" list predates the BREAKTHROUGH; direction (2)/(1) are essentially
+what `IMPI` gating achieves.)
 
 ## What the feature is supposed to do
 

--- a/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
+++ b/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
@@ -21,38 +21,57 @@ answers it: every initialised instrument header starts with the 4-byte magic
 (sample-only loads, `Shift-Enter` bulk-load — neither touches the instrument
 region) practically never spell `IMPI` (four exact bytes, ~1 in 4e9).
 
-`Music_InstrumentHasEnvelopes` now gates on `IMPI` FIRST:
-- **No `IMPI`** → not a real instrument → report "default" → caller clears it to
-  template. Garbage can never be preserved; the renderer never sees a non-`IMPI`
-  header. **Crash class eliminated at the signal, not patched downstream.**
-- **`IMPI` present** → real instrument; its envelope structs are guaranteed valid,
-  so the template-diff on the envelope section is now safe and decides preserve
-  (user drew something) vs clear+reinit (real but blank).
+### Final policy: "always remap, keep envelopes" (chosen by the maintainer)
 
-The old node-count>25 heuristic is kept as a *secondary* belt; the
-`I_MapEnvelope` `MaxNode<=25` clamp on `main` remains the independent
-renderer-side backstop.
+A new helper `Music_InstrumentIsReal` (AX = instrument#) returns ZF=1 iff the
+header starts with `IMPI`. `F_SetControlInstrument`'s Initialise=YES loop now:
+
+```
+for each slot 0..98:
+    if NOT IsReal(slot):            ; no IMPI -> garbage
+        Music_ClearInstrument(slot) ; -> valid blank template (IMPI, 0-node env)
+    ; slot is now guaranteed valid (IMPI + valid envelope section)
+    if matching sample exists:
+        copy sample name -> instrument name (offset 20h)
+        fill 120-note keymap        (offset 41h) -> all notes play this sample
+    ; the envelope section (130h+) is NEVER written here
+```
+
+Consequences:
+- **Garbage can never reach the envelope renderer** — non-IMPI slots are cleared
+  to a valid template before anything else. **Crash class eliminated at the signal.**
+- **Drawn envelopes always survive** — the loop never touches bytes 130h+, on any
+  slot, real or just-cleared.
+- **Every instrument ends up mapped & playable** — name + keymap are (re)written
+  for every slot with a matching sample, including ones that have a drawn
+  envelope. (The earlier "skip slots that have envelopes" design left such a slot
+  *silent* because its default keymap points every note at sample 0 — that bug is
+  gone.)
+
+Trade-off the maintainer accepted: a hand-crafted real instrument's custom name
+and multi-sample keymap get overwritten with the simple auto-mapping. That is the
+intent of "Initialise = YES"; a user who wants zero changes answers **No** (which,
+on stable `main`, already flips to Instrument mode and keeps everything).
+
+The `I_MapEnvelope` `MaxNode<=25` clamp on `main` remains as an independent
+renderer-side backstop for any malformed-but-IMPI instrument loaded from disk.
 
 ### Why this is strictly safe
-Worst case (a user somehow drew an envelope on a slot that never got `IMPI`):
-that slot is cleared instead of preserved — it degrades to stable IT2.15
-behaviour for that one slot. **It never crashes.** Normal case: real instruments
-with drawn envelopes carry `IMPI` and are preserved.
+The renderer never sees a non-IMPI header, and the envelope section of any slot
+is never mutated by this path. There is no longer a "drew on a magic-less slot"
+failure mode to worry about (we don't gate on envelopes at all anymore) — the
+only thing `IMPI` decides is whether to clear garbage first. **It never crashes.**
 
-### The one open question for the verifier
-Does drawing an envelope always land on an `IMPI` header? `F_NewSong` only clears
-instruments when the user ticks that box, so slots *can* be garbage — but the
-instrument-edit UI very likely initialises a slot on first edit (confirm on real
-hardware). If it does, `IMPI` is fully airtight. If some edit path writes
-envelope bytes onto a magic-less slot, that slot degrades safely to "cleared"
-(no crash), and that path should be taught to write the template on first
-envelope edit.
+### What the verifier should still confirm on real hardware
+The original crash is EMM386-#12 / real-hardware-specific (DOSBox-X can't
+reproduce it). Confirm on a DOS PC: (1) the old repro (Shift-Enter bulk-load →
+F12 Samples→Instruments → Initialise=YES) no longer crashes; (2) a genuinely
+drawn envelope survives the flip AND the instrument is now mapped/playable; (3)
+a normal song still converts as expected.
 
 ---
 
-(Original diagnosis below, retained for context. Note: the "directions for a
-correct fix" list predates the BREAKTHROUGH; direction (2)/(1) are essentially
-what `IMPI` gating achieves.)
+(Original diagnosis below, retained for context.)
 
 ## What the feature is supposed to do
 

--- a/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
+++ b/RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md
@@ -1,0 +1,128 @@
+# Feature: Retain drawn envelopes when converting Samples → Instruments
+
+**Status: WORK IN PROGRESS — DO NOT MERGE.** This PR re-introduces a feature that
+was scalpel-removed from `main` because it crashed. It is parked here, with the
+code and full diagnosis, so a stronger agent can implement it *correctly*. The
+shipping `main` is the stable IT2.15-equivalent behaviour (always clear+re-init);
+this branch is the opposite — it brings the fragile feature back so it can be
+fixed, not shipped as-is.
+
+## What the feature is supposed to do
+
+In Impulse Tracker you can be in **Sample mode** or **Instrument mode** (F12 song
+flag, bit 2 of `[SongData:2Ch]`). A user can open an instrument's envelope editor
+(F4) and draw Volume / Pan / Pitch / Filter envelopes *while still in Sample
+mode*. Those envelopes don't sound in Sample mode, but the data is written into
+the instrument header. People pre-draw envelopes this way, then flip
+Samples → Instruments to start using them.
+
+When you flip to Instrument mode via F12, IT asks **"Initialise Instruments?"**.
+Answering **YES** runs `F_SetControlInstrument` (`IT_F.ASM`), whose **upstream
+IT2.15 behaviour** is: `Music_ClearAllInstruments` (wipe every instrument header
+to the default template), then walk slots 0..99 copying the matching sample's
+name and filling the 120-note keymap.
+
+**The desired feature:** make "Initialise Instruments = YES" set up the
+sample→instrument mappings on *blank* instruments **without wiping envelopes the
+user already drew**.
+
+## Why it was removed (the crash, in detail)
+
+The attempt (`d8ec842`, then patched by `4e4eb9a` / `ed10913` / `3d2412b`)
+replaced the unconditional clear with a **per-slot test**,
+`Music_InstrumentHasEnvelopes` (`IT_MUSIC.ASM`): for each slot it compared the
+live instrument's envelope bytes (`130h..554`, the Vol/Pan/Pitch envelope structs
++ padding) against the default `InstrumentHeader` template. If they differed, the
+slot was assumed to hold user-drawn data and was **preserved** (skip clear, skip
+re-init). If they matched, the slot was cleared + re-init'd as before.
+
+The fatal flaw: **a slot whose envelope differs from the template is not
+necessarily user-drawn — it is very often uninitialised garbage.** Instrument
+slots are full of leftover bytes after:
+- loading a song in Sample mode (instruments never touched),
+- `Shift-Enter` bulk-load of a module's samples (touches samples, not instruments).
+
+The test saw garbage ≠ template, called it "user data", and **preserved the
+garbage instead of clearing it**. The instrument-mode renderer `I_MapEnvelope`
+(`IT_I.ASM`) then read a **garbage envelope node count** and ran an unbounded
+node-draw loop → wild write → **EMM386 exception #12 / hard crash** on real
+hardware.
+
+A *second*, independent crash came from the dialog: a focus-index value of `6`
+(then `4`) into `O1_InitialiseInstrumentList` pointed past the list terminator
+into adjacent bytes → garbage object pointer → wild `Call` the instant the prompt
+opened. (See `3d2412b`.)
+
+### Partial mitigations that were tried (still insufficient)
+
+- `ed10913`: clamp `I_MapEnvelope` `MaxNode ≤ 25` and have
+  `Music_InstrumentHasEnvelopes` reject slots whose node count at
+  `+131h/+183h/+1D5h` exceeds 25 (treat as "default" → clear). **This clamp is
+  good and was KEPT on `main`** — it is pure defensive insurance for the renderer
+  regardless of this feature. But it does not solve the core ambiguity: a garbage
+  header with node counts that *happen* to be ≤ 25 still gets "preserved".
+- `4e4eb9a` / `3d2412b`: dialog focus-index fixes. Fixing symptoms, not cause.
+
+## The real problem to solve
+
+**There is no reliable way, from the header bytes alone, to distinguish
+"user deliberately drew an envelope on this slot" from "this slot is
+uninitialised garbage that happens not to match the template".** Template-diff is
+the wrong signal. A correct implementation needs a *positive, trustworthy* signal
+that a slot holds intentional instrument data.
+
+### Suggested directions for a correct fix (for the better agent)
+
+1. **Explicit "instrument touched" flag.** Track, per instrument slot, whether the
+   user has actually initialised/edited it (e.g. set a bit when the envelope
+   editor writes to that slot, or when the instrument is loaded from disk as an
+   instrument). Only preserve slots with that bit set. Garbage slots never set it.
+2. **Full structural validation before preserve.** Don't just check node count ≤
+   25 on three offsets — validate the *entire* envelope struct (node count,
+   per-node tick ordering monotonic, loop/sustain points in range, flags sane). A
+   slot that fails any check is garbage → clear it. Only a fully-valid envelope is
+   preserved. This is more defensive than (1) but still heuristic.
+3. **Scope the feature narrowly.** Only preserve envelopes on slots whose matching
+   *sample* exists AND whose instrument header is otherwise default except the
+   envelope section — i.e. the exact "I drew an envelope on an otherwise-blank
+   instrument in Sample mode" case the feature targets. Anything else → clear.
+4. **Make it opt-in / undoable.** Consider a third dialog choice ("Initialise but
+   keep envelopes") so the destructive default stays the safe, well-understood
+   IT2.15 path and envelope-preservation is an explicit, separate action.
+
+Whatever the approach: **the envelope renderer (`I_MapEnvelope`) must never be
+handed an unvalidated node count.** The `MaxNode ≤ 25` clamp on `main` is a
+backstop, not a license to feed it garbage.
+
+## What this branch contains
+
+Re-applied on top of stable `main`:
+- `IT_F.ASM` `F_SetControlInstrument`: the per-slot
+  `Music_InstrumentHasEnvelopes` / `Music_ClearInstrument` preservation loop
+  (dialog focus index `4` = "No"), plus the `Extrn`s.
+- `IT_MUSIC.ASM`: the `Music_InstrumentHasEnvelopes` helper (with the
+  garbage-rejection guard) + its `Global` decl.
+
+Deliberately **NOT** reverted (kept from stable `main`):
+- `IT_G.ASM` `Glbl_Shift_F4` Instrument-mode gate — unrelated good stability fix.
+- `IT_I.ASM` `I_MapEnvelope` `MaxNode ≤ 25` clamp — keep as backstop.
+
+## Reference commits
+
+| Commit | Role |
+|--------|------|
+| `d8ec842` | introduced per-slot envelope preservation (the feature) |
+| `4e4eb9a` | dialog default-focus "No" (symptom patch) |
+| `ed10913` | `MaxNode ≤ 25` clamp + garbage-reject (mitigation, partly kept) |
+| `3d2412b` | dialog focus-index `6→4` wild-call fix (symptom patch) |
+| `b5a0c66` | **the scalpel** — removed the feature from `main` (this branch reverts the IT_F/IT_MUSIC parts of it) |
+
+## How to verify a future fix
+
+Repro the crash first (to confirm you can see it): build, then in DOSBox-X / on a
+DOS PC, `Shift-Enter` bulk-load a module's samples (so instrument slots hold
+garbage), then F12 → Samples→Instruments → Initialise = YES. The pre-fix feature
+crashes (EMM386 #12). A correct fix must: (a) not crash on garbage slots, (b)
+actually preserve a genuinely user-drawn envelope across the flip, (c) still clear
+truly-blank instruments. All three, verified on real hardware (the crash is
+environment-sensitive — see CLAUDE.md on DOSBox-X vs real-hardware repro).


### PR DESCRIPTION
**Status: rebuilt on the right signal + the cleaner policy. Still DO NOT MERGE without real-hardware verification.**

## The signal: `IMPI` magic
Every initialised instrument header starts with the 4-byte **`IMPI`** magic at offset 0 (`InstrumentHeader` template `IT_MUSIC.ASM:371`; `Music_ClearInstrument` copies it; disk loads write it). Garbage slots (sample-only loads, Shift-Enter bulk-load) never spell it. The old code asked 'do the envelope bytes differ from the template?' — garbage passes that trivially and crashed `I_MapEnvelope` (EMM386 #12). The right question is 'is this a real instrument?' → `Music_InstrumentIsReal` (ZF=1 iff `IMPI`).

## The policy: always remap, keep envelopes
`F_SetControlInstrument` Initialise=YES loop:
```
for each slot 0..98:
    if NOT IsReal(slot):            # no IMPI -> garbage
        Music_ClearInstrument       # -> valid blank template
    if matching sample exists:
        write name + 120-note keymap
    # envelope section (130h+) is NEVER written
```
- Garbage can never reach the renderer (cleared first). **Crash class gone at the signal.**
- Drawn envelopes always survive (130h+ never touched, on any slot).
- Every instrument ends up mapped & playable — fixes the earlier design's *silent-instrument* bug (an envelope-bearing slot was skipped and left pointing every note at sample 0).

Backstop kept: `I_MapEnvelope` MaxNode≤25 clamp on main.

## Trade-off (accepted)
A hand-crafted instrument's custom name/keymap is overwritten by the auto-mapping on Initialise=YES — the intent of 'Initialise'. To keep everything untouched, answer **No** (which on stable main already flips to Instrument mode and preserves all data).

## Why still DO NOT MERGE
The original crash is EMM386-#12 / real-hardware-specific; DOSBox-X cannot reproduce it. Verify on a DOS PC: (1) old repro no longer crashes, (2) a drawn envelope survives the flip AND the instrument is mapped/playable, (3) a normal song converts as expected. Full detail in `RETAIN-ENVELOPES-SAMPLES-TO-INSTRUMENTS-NOTES.md`.

Builds clean: IT.EXE + 42 drivers, no TASM/TLINK errors.